### PR TITLE
An example of mobile specific image

### DIFF
--- a/clients/able-brand-identity/index.html
+++ b/clients/able-brand-identity/index.html
@@ -258,7 +258,8 @@ We create meaningful food moments for people, business and planet. <i>(Alternati
 
 					<div class="section-asset-image-blocks row">
 						<div class="col-xs-12">
-							<img class="section-asset-image wow imageScaleIn" data-wow-delay="0.6s" src="assets/able_brand_drivers.png" />
+							<img class="section-asset-image wow imageScaleIn hidden-xs" data-wow-delay="0.6s" src="assets/able_brand_drivers.png" />
+							<img class="section-asset-image wow imageScaleIn visible-xs-block" data-wow-delay="0.6s" src="https://via.placeholder.com/728x250.png" />
 						</div>
 					</div>
 


### PR DESCRIPTION
@MathiasHN 

Example of using mobile specific images.

Should they remain full width, or indented to align with text?

![image](https://user-images.githubusercontent.com/67565/50796707-c770c780-12d2-11e9-9074-a570696c7686.png)
